### PR TITLE
Drop runscope "pause" steps

### DIFF
--- a/index.js
+++ b/index.js
@@ -317,7 +317,7 @@ var runscopeConverterV1 = {
 		runscopeJson = this.validateRunscope(runscopeJson);
 		var collection = this.initCollection(runscopeJson);
 
-		_.each(runscopeJson.steps, function(step) {
+		_.each(_.filter(runscopeJson.steps, function(step) { return step.step_type !== 'pause'; }), function(step) {
 			oldThis.addRequest(collection, oldThis.getRequestFromStep(step));
 		});
 

--- a/test/runscope2.json
+++ b/test/runscope2.json
@@ -151,7 +151,11 @@
       ], 
       "data": "", 
       "method": "GET"
-    }, 
+    },
+    {
+      "duration": 20,
+      "step_type": "pause"
+    },
     {
       "body": "RAW BODY", 
       "form": {}, 


### PR DESCRIPTION
Runscope has pause-only steps. This change excludes these steps from the postman output.